### PR TITLE
[dockerfile] pfad auf neue NGINX version geupdated

### DIFF
--- a/asciidocs/dockerfile.adoc
+++ b/asciidocs/dockerfile.adoc
@@ -205,7 +205,7 @@ MAINTAINER stuetz
 
 RUN apt update
 RUN apt install -y nginx
-COPY index.html /usr/share/nginx/index.html
+COPY index.html /var/www/html/index.nginx-debian.html
 
 EXPOSE 80
 ENTRYPOINT ["/usr/sbin/nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Ein nginx-update hat den Pfad der `index.html`-Datei geändert, dadurch geht die vorhandene Dockerfile nicht. 
Diese PR ändert den Pfad auf den neuen und sollte somit das Befolgen der Anleitung wieder ermöglichen.